### PR TITLE
refactor: do not render embed code on keystone-editor.twreporter.org

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,13 +6,32 @@ import './styles/main.css';
 import { Noise } from './components/utility/noise';
 import { ScrollCounter } from './components/utility/ScrollCounter';
 
-ReactDOM.createRoot(document.getElementById('multimedia_microloan')!).render(
-  <React.StrictMode>
-    {/* <Noise /> */}
-    {/* <ScrollCounter /> */}
-    {/* <div style={{ height: '122px', width: '100vw', backgroundColor: '#00000033', position: 'fixed', top: 0, left: 0, zIndex: 1000 }}></div> */}
-    <ScrollSmootherWrapper>
-      <ScrollAnimationApp />
-    </ScrollSmootherWrapper>
-  </React.StrictMode>
-);
+const host = document.location.hostname
+if (
+  host !== 'keystone-editor.twreporter.org' &&
+  host !== 'staging-keystone-editor.twreporter.org'
+) {
+  ReactDOM.createRoot(document.getElementById('multimedia_microloan')!).render(
+    <React.StrictMode>
+      {/* <Noise /> */}
+      {/* <ScrollCounter /> */}
+      {/* <div style={{ height: '122px', width: '100vw', backgroundColor: '#00000033', position: 'fixed', top: 0, left: 0, zIndex: 1000 }}></div> */}
+      <ScrollSmootherWrapper>
+        <ScrollAnimationApp />
+      </ScrollSmootherWrapper>
+    </React.StrictMode>
+  );
+} else {
+  ReactDOM.createRoot(document.getElementById('multimedia_microloan')!).render(
+    <div
+      style={{
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        color: 'white',
+        padding: '30px',
+      }}
+    >
+      多媒體 embed code（編輯模式，不載入影片）
+    </div>
+  );
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig(({ command }) => ({
     }
   },
   server: {
+    host: true,
     port: 3000,
     open: true,
   },


### PR DESCRIPTION
### PR 說明
- commit  c407b9a ：解決 embed code 干擾 keystone-editor.twreporter.org 編輯畫面的問題
- commit 03f16c2：調整 vite.config.ts，讓 dev server 可以用 localhost 以外的方式連線。手機若是和電腦連同一個 WiFi，手機就可以透過電腦的 en0 的 private IP 連到 dev server，手機即可以進行測試。