### PR TITLE
fix(scroll): resolve ScrollSmoother layout issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 </head>
 <body>
     <div id="multimedia_loancrisis"></div>
+    <div style="height: 300vh; background-color: pink;"></div>
     <script type="module" src="/src/index.tsx"></script>
 </body>
 </html> 

--- a/src/components/utility/ScrollSmootherWrapper.tsx
+++ b/src/components/utility/ScrollSmootherWrapper.tsx
@@ -23,23 +23,46 @@ export const ScrollSmootherWrapper = ({ children }: ScrollSmootherWrapperProps) 
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    let smoother : ScrollSmoother
     if (wrapperRef.current && !isMobile()) {
-      ScrollSmoother.create({
+     smoother = ScrollSmoother.create({
         wrapper: '#smooth-wrapper',
         content: '#smooth-content',
         smooth: 2,
         effects: true,
         normalizeScroll: false,
+        onUpdate: () => {
+          if (smoother) {
+            const scrollY = smoother.scrollTop();
+            const maxScroll = smoother.content().offsetHeight - window.innerHeight;
+
+            console.log({
+              scrollY,
+              maxScroll,
+            })
+            if (scrollY >= maxScroll) {
+              //smoother.paused(true); // or smoother.kill();
+              document.getElementById('smooth-wrapper').style.position = 'relative';
+              document.getElementById('smooth-content').style.transform = '';
+              document.body.classList.remove('scroll-lock-multimedia-loadcrsis');
+            } else {
+              document.getElementById('smooth-wrapper').style.position = 'fixed';
+              document.body.classList.add('scroll-lock-multimedia-loadcrsis');
+            }
+          }
+        }
       });
     }
 
     return () => {
-      ScrollSmoother.get()?.kill();
+      if (smoother) {
+        smoother.kill();
+      }
     };
   }, []);
 
   return (
-    <div id="smooth-wrapper" ref={wrapperRef}>
+    <div id="smooth-wrapper" ref={wrapperRef} style={{backgroundColor: '#f1f1f1'}}>
       <div id="smooth-content">{children}</div>
     </div>
   );

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -26,6 +26,10 @@ body::-webkit-scrollbar {
   display: none;
 }
 
+body.scroll-lock-multimedia-loadcrsis {
+  overflow: hidden;
+}
+
 :root {
   --text-xs: 0.75rem;
   --text-sm: 0.875rem;


### PR DESCRIPTION
### PR 說明
桌機版使用 gsap 的 `ScrollSmoother`，該 smoother 會強制將他的 children 變成 `position: fixed`，導致放在後面的 element 會被 `position: fixed` 的元素給影響，無法在正確的位置上滾動。
此 PR 用 workaround 的方式解決此問題，當 smoother 滑到底時，會被改成 `position: relative`，讓後面的 element 可以正常滑動。