### PR TITLE
fix: scrollY is never larger than maxScrollY on windows

### DIFF
--- a/src/components/utility/ScrollSmootherWrapper.tsx
+++ b/src/components/utility/ScrollSmootherWrapper.tsx
@@ -40,7 +40,9 @@ export const ScrollSmootherWrapper = ({ children }: ScrollSmootherWrapperProps) 
               scrollY,
               maxScroll,
             })
-            if (scrollY >= maxScroll) {
+
+            const scrollBuffer = 50
+            if (scrollY >= maxScroll - scrollBuffer) {
               //smoother.paused(true); // or smoother.kill();
               document.getElementById('smooth-wrapper').style.position = 'relative';
               document.getElementById('smooth-content').style.transform = '';


### PR DESCRIPTION
## Bug 說明
在 windows 電腦上，會遇到 `scrollY` 的值無法大於等於 `maxScrollY` 的值，導致 `ScrollAnimationWrapper` 無法如期呈現畫面，使用者會被卡住，無法往下滑，閱讀文章。

demo：
https://twreporter.slack.com/files/U05FXRM8Y8G/F0998Q5TFQU/________2025-08-06_18_46_46_.mov